### PR TITLE
Improve docs on JavaScript SDK

### DIFF
--- a/javascript-sdk.md
+++ b/javascript-sdk.md
@@ -105,7 +105,8 @@ When filtering, you have access to the following operators: `=`, `>`, `>=`, `<`,
 
 See the following quick start guides to integrate CASE with popular front-end frameworks:
 
+- [Get started with Angular](angular.md)
+- [Get started with Astro](astro.md)
 - [Get started with React](react.md)
 - [Get started with Svelte](svelte.md)
-- [Get started with Angular](angular.md)
 - [Get started with Vue](vue.md)

--- a/javascript-sdk.md
+++ b/javascript-sdk.md
@@ -2,7 +2,7 @@
 id: javascript-sdk
 ---
 
-# Javascript SDK
+# JavaScript SDK
 
 Use the **Manifest JS SDK** to fetch and manipulate your data from your JS client.
 

--- a/javascript-sdk.md
+++ b/javascript-sdk.md
@@ -103,7 +103,7 @@ When filtering, you have access to the following operators: `=`, `>`, `>=`, `<`,
 
 ## Get started with your favorite front-end framework
 
-See the following quick start guides to integrate CASE with popular front-end frameworks:
+See the following quick start guides to integrate Manifest with popular front-end frameworks:
 
 - [Get started with Angular](angular.md)
 - [Get started with Astro](astro.md)


### PR DESCRIPTION
I was sifting through the docs and saw that you had a quick start on Astro, but it wasn’t being referenced in a place where all other quick starts were.

Javascript → JavaScript ([why this distinction matters today](https://javascript.tm/))

---

💖