### PR TITLE
Fix tiny typo: þ -> p in package.json

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -69,7 +69,7 @@ If you already have a frontend app, you can run the `npx add-manifest` command f
 
 #### Note with PNMP
 
-As [PNPM](https://pnpm.io/fr/) blocks postinstall scripts, we have to adapt the `þackage.json`. Add this to your `package.json` file before doing `pnpm install`:
+As [PNPM](https://pnpm.io/fr/) blocks postinstall scripts, we have to adapt the `package.json`. Add this to your `package.json` file before doing `pnpm install`:
 
 ```json
   "pnpm": {


### PR DESCRIPTION
I happened to notice this strangeness and presumed it was a mistake, so I'm trying to fix it.